### PR TITLE
Fix: Resolve initial white screen and ensure dark intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -873,18 +873,27 @@
 
     /* INITIUM POST ONUS PAGINAE COMPLETUM */
     document.addEventListener('DOMContentLoaded',()=>{
+        if (document.body) { // Ensure body exists
+            document.body.style.opacity = '0';
+            document.body.style.backgroundColor = 'var(--kenoma-profundum)';
+        }
+
         initAetherCanvasPerfectissima();
-        M_DIVINITAS.idFrameAnim=requestAnimationFrame(ansaAnimMagistraPerfectissima);
-        D_ELEMENTA.btnVisioPlena.addEventListener('click',()=>{
-            const e=document.documentElement;
-            if(!document.fullscreenElement&&!document.webkitFullscreenElement){
-                if(e.requestFullscreen)e.requestFullscreen().catch(err => console.error(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`));
-                else if(e.webkitRequestFullscreen)e.webkitRequestFullscreen();
-            }
-        });
-        const bodyStyle = getComputedStyle(document.body);
-        const totalIntroTime = (parseFloat(bodyStyle.animationDelay.replace('s','')) + parseFloat(bodyStyle.animationDuration.replace('s',''))) * 1000;
-        setTimeout(initiaTheophaniamPerfectissimam, Math.max(0, totalIntroTime - 2000));
+        M_DIVINITAS.idFrameAnim = requestAnimationFrame(ansaAnimMagistraPerfectissima);
+
+        if (D_ELEMENTA.btnVisioPlena) { // Ensure button exists before adding listener
+            D_ELEMENTA.btnVisioPlena.addEventListener('click',()=>{
+                const e=document.documentElement;
+                if(!document.fullscreenElement&&!document.webkitFullscreenElement){
+                    if(e.requestFullscreen)e.requestFullscreen().catch(err => console.error(`Error attempting to enable full-screen mode: ${err.message} (${err.name})`));
+                    else if(e.webkitRequestFullscreen)e.webkitRequestFullscreen();
+                }
+            });
+        }
+
+        // Call initiaTheophaniamPerfectissimam after a short delay
+        // This allows initial styles to apply and DOM to be fully ready.
+        setTimeout(initiaTheophaniamPerfectissimam, 100);
     });
 
   </script>


### PR DESCRIPTION
Modifications to ensure the page initializes with a dark screen (`opacity: 0` on body, background color set) and that animations commence correctly.

Key changes:
- Explicitly set body opacity to 0 and background color via JavaScript on DOMContentLoaded as a safeguard.
- Adjusted the `DOMContentLoaded` logic to robustly call `initiaTheophaniamPerfectissimam` after a short delay, removing dependency on a deleted CSS animation for timing.
- Verified that the `fiatLuxCosmica` effect is the sole trigger for making the body content opaque, ensuring the transition from darkness to light is tied to this event.
- Reviewed recent refactoring of effect initiations (moved into `fiatLuxCosmica`) for errors and confirmed general soundness.

These changes address the issue where the page might have appeared as a blank white screen by enforcing initial darkness and ensuring the light-up sequence is correctly triggered.